### PR TITLE
fix(smart-render): Discart selection just for update changes

### DIFF
--- a/packages/smart-render/src/index.tsx
+++ b/packages/smart-render/src/index.tsx
@@ -58,11 +58,13 @@ export default class SmartRender extends EditorPlugin {
         const { template } = this.editor.state;
         const changes = getChanges(canvas, template);
         if (changes.length) {
+          canvas.discardActiveObject(new Event("NO_SYNC"));
           changes.forEach(({ canvasItem, changedProperties }) => {
             canvasItem.set(changedProperties);
             ["left", "top"].some((i) => hasOwnProperty(changedProperties, i)) &&
               canvasItem.setCoords();
           });
+          this.editor.events.emit("ApplySelection", false);
           canvas.requestRenderAll();
         }
       }


### PR DESCRIPTION
Please see #79

Fixes #79

----

a seleção do canvas é descartada, mas em seguida é refeita.