### PR TITLE
fix(inspect-object-font): FontFamily: use `value`

### DIFF
--- a/packages/inspect-object-font/src/index.tsx
+++ b/packages/inspect-object-font/src/index.tsx
@@ -103,7 +103,7 @@ export default class InspectObjectFont extends EditorPlugin {
                 <GridFontFamily>
                   <InputText
                     placeholder="Fonte"
-                    defaultValue={sharedProperty(
+                    value={sharedProperty(
                       ({ fontFamily }) => fontFamily,
                       "",
                     )(selectedObjects)}


### PR DESCRIPTION
instead of `defaultValue`

Fixes #106