### PR TITLE
fix: fixes imports of fantastic-images/lib to named imports

### DIFF
--- a/packages/list-objects/src/actions/with-selected/remove-selected/index.ts
+++ b/packages/list-objects/src/actions/with-selected/remove-selected/index.ts
@@ -18,7 +18,7 @@
  */
 //endregion
 
-import REMOVE_OBJECT from "@fantastic-images/lib/dist/model/mutations/remove-object";
+import { REMOVE_OBJECT } from "@fantastic-images/lib/dist/model/mutations/remove-object";
 import { ActionItem } from "@ui5/react-user-interface/lib/Actions";
 import ListObjects from "../../..";
 import { getKey } from "../../../get-key";

--- a/packages/list-objects/src/index.tsx
+++ b/packages/list-objects/src/index.tsx
@@ -18,7 +18,7 @@
  */
 //endregion
 
-import REMOVE_OBJECT from "@fantastic-images/lib/dist/model/mutations/remove-object";
+import { REMOVE_OBJECT } from "@fantastic-images/lib/dist/model/mutations/remove-object";
 import { Actions } from "@ui5/react-user-interface/lib/Actions";
 import { LayerList } from "@ui5/react-user-interface/lib/LayerList";
 import { LayerListItem } from "@ui5/react-user-interface/lib/LayerListItem";

--- a/packages/list-static/src/index.tsx
+++ b/packages/list-static/src/index.tsx
@@ -18,10 +18,8 @@
  */
 //endregion
 
-import {
-  ADD_STATIC_IMAGE,
-  REMOVE_STATIC_IMAGE,
-} from "@fantastic-images/lib/dist/model/mutations";
+import { ADD_STATIC_IMAGE } from "@fantastic-images/lib/dist/model/mutations/add-static-image";
+import { REMOVE_STATIC_IMAGE } from "@fantastic-images/lib/dist/model/mutations/remove-static-image";
 import { TemplateStaticImage } from "@fantastic-images/types/src/TemplateStaticImage";
 import { LayerList } from "@ui5/react-user-interface/lib/LayerList";
 import { LayerListHeader } from "@ui5/react-user-interface/lib/LayerListHeader";

--- a/packages/plugin-sync-objects/src/index.tsx
+++ b/packages/plugin-sync-objects/src/index.tsx
@@ -18,7 +18,7 @@
  */
 //endregion
 
-import UPDATE_OBJECT from "@fantastic-images/lib/dist/model/mutations/update-object";
+import { UPDATE_OBJECT } from "@fantastic-images/lib/dist/model/mutations/update-object";
 import { findIndexByObject } from "@ui5/shared-lib/lib/canvas/find-index-by-object";
 import { EditorPlugin } from "@ui5/shared-lib/lib/editor/EditorPlugin";
 import { fabric } from "fabric";


### PR DESCRIPTION
Veja https://github.com/guesant/fantastic-images/issues/42 e
https://github.com/guesant/fantastic-images/issues/43